### PR TITLE
Fix wrong DB path check

### DIFF
--- a/database.py
+++ b/database.py
@@ -56,7 +56,9 @@ def after_cursor_execute(conn, cursor, statement, parameters, context, executema
 
 
 # Crear la base de datos solo si no existe
-if not os.path.exists("./repos.db"):
+# Obtener la ruta real del archivo de base de datos a partir de DATABASE_URL
+db_path = DATABASE_URL.replace("sqlite:///", "")
+if not os.path.exists(db_path):
     Base.metadata.create_all(bind=engine)
 
 inspector = inspect(engine)


### PR DESCRIPTION
## Summary
- ensure database is checked using the same path as `DATABASE_URL`
- keep newline at EOF

## Testing
- `python -m py_compile main.py github.py techAI.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_688277ecbe9c8329a12df43d639c0da5